### PR TITLE
Remove interactive cleanup from main loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,11 +118,8 @@ def main():
             continue
 
         process_frame(frame)
-        if cv2.waitKey(1) & 0xFF == ord('q'):
-            break
 
     cap.release()
-    cv2.destroyAllWindows()
 
 if __name__ == "__main__":
     print("Starting plate detector (CPU-only)...")


### PR DESCRIPTION
## Summary
- update `main.py` to remove `cv2.waitKey` and `cv2.destroyAllWindows`
- leave the frame processing loop running continuously

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845cc6996c8832f861626557c5f2b53